### PR TITLE
Add set language srv fix

### DIFF
--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -218,7 +218,7 @@ const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetSt
 
 /** Function that gets language set to a robot
  */
-  const std::string& getLanguageLocal( const qi::SessionPtr& session)
+const std::string& getLanguageLocal( const qi::SessionPtr& session)
 {
   static std::string lang;
   std::cout << "Receiving service call of getting speech language" << std::endl;
@@ -229,7 +229,7 @@ const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetSt
   return lang;
 }
 
-  const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetStringRequest req)
+const std::string& getLanguage( const qi::SessionPtr& session )
 {
   std::cout << "ok3"<< std::endl;
   const std::string language = getLanguageLocal(session);

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -223,13 +223,17 @@ const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetSt
   static std::string lang;
   std::cout << "Receiving service call of getting speech language" << std::endl;
   qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
+  std::cout << "ok1" << std::endl;
   lang = p_text_to_speech.call<std::string>("getLanguage");
+  std::cout << "ok2"<< lang << std::endl;
   return lang;
 }
 
   const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetStringRequest req)
 {
+  std::cout << "ok3"<< std::endl;
   const std::string language = getLanguageLocal(session);
+  std::cout << "ok4"<< language << std::endl;
   return language;
 }
 

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -196,18 +196,13 @@ const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session 
 
 /** Function that sets language for a robot
  */
-static void setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
-{
-  std::cout << "Receiving service call of setting speech language" << std::endl;
-  qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
-  p_text_to_speech.call<void>("setLanguage", req.data);
-}
-
 bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
 {
   static bool success;
+  std::cout << "Receiving service call of setting speech language" << std::endl;
   try{
-    setLanguageLocal(session, req);
+    qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
+    p_text_to_speech.call<void>("setLanguage", req.data);
     success = true;
   }
   catch(const std::exception& e){

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -196,12 +196,8 @@ const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session 
 
 /** Function that sets language for a robot
  */
-static std_srvs::Empty& setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
+void setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
 {
-  static qi::Url robot_url;
-
-  robot_url = session->url();
-
   std::cout << "Receiving service call of setting speech language" << std::endl;
   qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
   p_text_to_speech.call<void>("setLanguage", req.data);
@@ -209,40 +205,32 @@ static std_srvs::Empty& setLanguageLocal( const qi::SessionPtr& session, naoqi_b
 
 const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
 {
+  static bool success;
   try{
     setLanguageLocal(session, req);
-    return true;
+    success = true;
   }
   catch(const std::exception& e){
-    return false;
+    success = false;
   }
+  return success;
 }
 
 /** Function that gets language set to a robot
  */
-  static std::string& getLanguageLocal( const qi::SessionPtr& session)
+  const std::string& getLanguageLocal( const qi::SessionPtr& session)
 {
-  static qi::Url robot_url;
-  static std::string language;
-
-  robot_url = session->url();
-
+  static std::string lang;
   std::cout << "Receiving service call of getting speech language" << std::endl;
   qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
-  language = p_text_to_speech.call<std::string>("getLanguage");
-  return language;
+  lang = p_text_to_speech.call<std::string>("getLanguage");
+  return lang;
 }
 
   const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetStringRequest req)
 {
-  std::string language;
-  try{
-    language = getLanguageLocal(session);
-    return language;
-  }
-  catch(const std::exception& e){
-    return language;
-  }
+  const std::string language = getLanguageLocal(session);
+  return language;
 }
 
 } // driver

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -203,7 +203,7 @@ static void setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::
   p_text_to_speech.call<void>("setLanguage", req.data);
 }
 
-const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
+bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
 {
   static bool success;
   try{
@@ -229,7 +229,7 @@ static std::string& getLanguageLocal( const qi::SessionPtr& session)
   return lang;
 }
 
-const std::string& getLanguage( const qi::SessionPtr& session )
+std::string& getLanguage( const qi::SessionPtr& session )
 {
   std::cout << "ok3 "<< std::endl;
   static std::string language = getLanguageLocal(session);

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -218,22 +218,12 @@ bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRe
 
 /** Function that gets language set to a robot
  */
-static std::string& getLanguageLocal( const qi::SessionPtr& session)
-{
-  static std::string lang;
-  std::cout << "Receiving service call of getting speech language" << std::endl;
-  qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
-  std::cout << "ok1" << std::endl;
-  lang = p_text_to_speech.call<std::string>("getLanguage");
-  std::cout << "ok2"<< lang << std::endl;
-  return lang;
-}
-
 std::string& getLanguage( const qi::SessionPtr& session )
 {
-  std::cout << "ok3 "<< std::endl;
-  static std::string language = getLanguageLocal(session);
-  std::cout << "ok4 "<< language << std::endl;
+  static std::string language;
+  std::cout << "Receiving service call of getting speech language" << std::endl;
+  qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
+  language = p_text_to_speech.call<std::string>("getLanguage");
   return language;
 }
 

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -196,7 +196,7 @@ const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session 
 
 /** Function that sets language for a robot
  */
-void setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
+static void setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
 {
   std::cout << "Receiving service call of setting speech language" << std::endl;
   qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
@@ -218,7 +218,7 @@ const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetSt
 
 /** Function that gets language set to a robot
  */
-const std::string& getLanguageLocal( const qi::SessionPtr& session)
+static std::string& getLanguageLocal( const qi::SessionPtr& session)
 {
   static std::string lang;
   std::cout << "Receiving service call of getting speech language" << std::endl;
@@ -231,9 +231,9 @@ const std::string& getLanguageLocal( const qi::SessionPtr& session)
 
 const std::string& getLanguage( const qi::SessionPtr& session )
 {
-  std::cout << "ok3"<< std::endl;
-  const std::string language = getLanguageLocal(session);
-  std::cout << "ok4"<< language << std::endl;
+  std::cout << "ok3 "<< std::endl;
+  static std::string language = getLanguageLocal(session);
+  std::cout << "ok4 "<< language << std::endl;
   return language;
 }
 

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -25,8 +25,6 @@
 
 #include <naoqi_bridge_msgs/SetString.h>
 
-#include <naoqi_bridge_msgs/GetString.h>
-
 #include <qi/applicationsession.hpp>
 
 namespace naoqi
@@ -42,7 +40,7 @@ const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session 
 
 const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req );
 
-const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetStringRequest req );
+const std::string& getLanguage( const qi::SessionPtr& session );
 
 } // driver
 } // helpers

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -38,9 +38,9 @@ const robot::Robot& getRobot( const qi::SessionPtr& session );
 
 const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session );
 
-const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req );
+bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req );
 
-const std::string& getLanguage( const qi::SessionPtr& session );
+std::string& getLanguage( const qi::SessionPtr& session );
 
 } // driver
 } // helpers

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -27,8 +27,6 @@
 
 #include <naoqi_bridge_msgs/GetString.h>
 
-#include <std_srvs/Empty.h>
-
 #include <qi/applicationsession.hpp>
 
 namespace naoqi

--- a/src/services/get_language.cpp
+++ b/src/services/get_language.cpp
@@ -36,7 +36,9 @@ void GetLanguageService::reset( ros::NodeHandle& nh )
 
 bool GetLanguageService::callback( naoqi_bridge_msgs::GetStringRequest& req, naoqi_bridge_msgs::GetStringResponse& resp )
 {
+  std::cout << "ok5" << std::endl;
   resp.data = helpers::driver::getLanguage(session_, req);
+  std::cout << "ok6" << resp.data << std::endl;
   return true;
 }
 

--- a/src/services/get_language.cpp
+++ b/src/services/get_language.cpp
@@ -36,9 +36,7 @@ void GetLanguageService::reset( ros::NodeHandle& nh )
 
 bool GetLanguageService::callback( naoqi_bridge_msgs::GetStringRequest& req, naoqi_bridge_msgs::GetStringResponse& resp )
 {
-  std::cout << "ok5" << std::endl;
   resp.data = helpers::driver::getLanguage(session_);
-  std::cout << "ok6" << resp.data << std::endl;
   return true;
 }
 

--- a/src/services/get_language.cpp
+++ b/src/services/get_language.cpp
@@ -37,7 +37,7 @@ void GetLanguageService::reset( ros::NodeHandle& nh )
 bool GetLanguageService::callback( naoqi_bridge_msgs::GetStringRequest& req, naoqi_bridge_msgs::GetStringResponse& resp )
 {
   std::cout << "ok5" << std::endl;
-  resp.data = helpers::driver::getLanguage(session_, req);
+  resp.data = helpers::driver::getLanguage(session_);
   std::cout << "ok6" << resp.data << std::endl;
   return true;
 }


### PR DESCRIPTION
```
[W] 1517473274.413834 25326 qitype.signal: Exception caught from signal subscriber: Call argument number 0 conversion failure from LogMessage to LogMessage. Function signature: (LogMessage).
ok5
ok3
Receiving service call of getting speech language
ok1
ok2English
ok4English
================================================================================REQUIRED process [naoqi_driver-2] has died!
process has died [pid 25318, exit code -11, cmd /home/pepper/catkin_ws/devel/lib/naoqi_driver/naoqi_driver_node --qi-url=tcp://133.11.216.93:9559 --roscore_ip=127.0.0.1 --network_interface=enp0s25 --namespace=naoqi_driver __name:=naoqi_driver __log:=/home/pepper/.ros/log/d9e4555a-0728-11e8-8836-b8aeed7315cd/naoqi_driver-2.log].
log file: /home/pepper/.ros/log/d9e4555a-0728-11e8-8836-b8aeed7315cd/naoqi_driver-2*.log
Initiating shutdown!
================================================================================
[naoqi_driver-2] killing on exit

```

```
pepper@pepper-desktop:~/catkin_ws/src/naoqi_driver$ rosservice call /naoqi_driver/get_language "{}" 
ERROR: transport error completing service call: unable to receive data from sender, check sender's logs for details
```
nanode, 

```
resp.data = helpers::driver::getLanguage(session_, req);
```
in `get_language.cpp` de ochiteiru.