### PR TITLE
Remove -Werror=deprecated-declarations to compile for melodic

### DIFF
--- a/CMakeLists_catkin.txt
+++ b/CMakeLists_catkin.txt
@@ -30,10 +30,6 @@ add_definitions(-DLIBQI_VERSION=${naoqi_libqi_VERSION_MAJOR}${naoqi_libqi_VERSIO
 
 catkin_package(LIBRARIES naoqi_driver_module naoqi_driver)
 
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=deprecated-declarations")
-endif()
-
 include_directories( include ${catkin_INCLUDE_DIRS})
 
 # create the different libraries


### PR DESCRIPTION
Melodicに対応するための[コミット](https://github.com/ros-naoqi/naoqi_driver/commit/6a09f9c89239450f8d324662ecd63c1e1185c38d)をgit cherry-pickしました。