### PR TITLE
Added missing bzip2 include directories for rosbag_storage

### DIFF
--- a/CMakeLists_catkin.txt
+++ b/CMakeLists_catkin.txt
@@ -26,11 +26,14 @@ find_package(catkin COMPONENTS
 find_package(OpenCV)
 find_package(orocos_kdl)
 
+find_package(BZip2 REQUIRED)
+add_definitions(${BZIP2_DEFINITIONS})
+
 add_definitions(-DLIBQI_VERSION=${naoqi_libqi_VERSION_MAJOR}${naoqi_libqi_VERSION_MINOR})
 
 catkin_package(LIBRARIES naoqi_driver_module naoqi_driver)
 
-include_directories( include ${catkin_INCLUDE_DIRS})
+include_directories( include ${catkin_INCLUDE_DIRS} ${BZIP2_INCLUDE_DIR})
 
 # create the different libraries
 add_library(


### PR DESCRIPTION
if we install bzip2 from soruce, we need this patch https://github.com/esteve/naoqi_driver/commit/4ad6886798ce927c0234e0dfcd02d75f10048a4b